### PR TITLE
Release 0.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.nhenneaux.jersey.connector.httpclient</groupId>
     <artifactId>jersey-httpclient-connector</artifactId>
-    <version>0.3.3</version>
+    <version>0.3.4</version>
 
     <name>Jersey Connector using java.net.http.HttpClient</name>
     <description>A Jersey connector using java.net.http.HttpClient and supporting HTTP/1.1 and HTTP/2.0 with the same client. The protocol is selected based on the server capabilities.</description>

--- a/src/main/java/com/github/nhenneaux/jersey/connector/httpclient/HttpClientConnector.java
+++ b/src/main/java/com/github/nhenneaux/jersey/connector/httpclient/HttpClientConnector.java
@@ -147,21 +147,23 @@ public class HttpClientConnector implements Connector {
         final Object entity = clientRequest.getEntity();
 
         final var responseBodyHandler = HttpResponse.BodyHandlers.ofInputStream();
+        final var method = clientRequest.getMethod();
         if (entity == null) {
-            requestBuilder.method(clientRequest.getMethod(), HttpRequest.BodyPublishers.noBody());
+            requestBuilder.method(method, HttpRequest.BodyPublishers.noBody());
             httpResponseCompletableFuture = httpClient.sendAsync(requestBuilder.build(), responseBodyHandler);
         } else if (entity instanceof byte[]) {
-            requestBuilder.method(clientRequest.getMethod(), HttpRequest.BodyPublishers.ofByteArray((byte[]) entity));
+            requestBuilder.method(method, HttpRequest.BodyPublishers.ofByteArray((byte[]) entity));
             httpResponseCompletableFuture = httpClient.sendAsync(requestBuilder.build(), responseBodyHandler);
         } else if (entity instanceof String) {
-            requestBuilder.method(clientRequest.getMethod(), HttpRequest.BodyPublishers.ofString((String) entity));
+            requestBuilder.method(method, HttpRequest.BodyPublishers.ofString((String) entity));
             httpResponseCompletableFuture = httpClient.sendAsync(requestBuilder.build(), responseBodyHandler);
         } else {
-            httpResponseCompletableFuture = streamRequestBody(clientRequest, requestBuilder);
+            httpResponseCompletableFuture = streamRequestBody(clientRequest, requestBuilder, responseBodyHandler, method);
         }
         return readTimeoutOptional.map(readTimeout -> httpResponseCompletableFuture.orTimeout(readTimeout.toMillis() + 100, TimeUnit.MILLISECONDS))
                 .orElse(httpResponseCompletableFuture);
     }
+
 
     Future<ClientResponse> toJerseyResponseWithCallback(ClientRequest clientRequest, CompletableFuture<HttpResponse<InputStream>> inputStreamHttpResponseFuture, AsyncConnectorCallback asyncConnectorCallback) {
         final CompletableFuture<ClientResponse> clientResponseCompletableFuture = inputStreamHttpResponseFuture.thenApply(inputStreamHttpResponse -> toJerseyResponse(clientRequest, inputStreamHttpResponse));
@@ -175,7 +177,7 @@ public class HttpClientConnector implements Connector {
         return clientResponseCompletableFuture;
     }
 
-    CompletableFuture<HttpResponse<InputStream>> streamRequestBody(ClientRequest clientRequest, HttpRequest.Builder requestBuilder) {
+     CompletableFuture<HttpResponse<InputStream>> streamRequestBody(ClientRequest clientRequest, HttpRequest.Builder requestBuilder, HttpResponse.BodyHandler<InputStream> responseBodyHandler, String method) {
         @SuppressWarnings("squid:S2095") // The stream cannot be closed here and is closed in Jersey client.
         final PipedOutputStream pipedOutputStream = new PipedOutputStream();
         @SuppressWarnings("squid:S2095") // The stream cannot be closed here and is closed in Jersey client.
@@ -183,21 +185,15 @@ public class HttpClientConnector implements Connector {
         connectStream(pipedOutputStream, pipedInputStream);
         clientRequest.setStreamProvider(contentLength -> pipedOutputStream);
 
-        final HttpRequest httpRequest = requestBuilder.method(clientRequest.getMethod(), HttpRequest.BodyPublishers.ofInputStream(() -> pipedInputStream)).build();
-        final CompletableFuture<HttpResponse<InputStream>> httpResponseCompletableFuture = httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream());
-
-        final Runnable entityWriter = () -> {
-            try {
-                clientRequest.writeEntity();
-            } catch (IOException e) {
-                httpResponseCompletableFuture.cancel(true);
-                throw new ProcessingException("The sending process failed with I/O error, " + e.getMessage(), e);
-            }
-        };
-
-        final CompletableFuture<Void> sendingFuture = httpClient.executor().map(executor -> CompletableFuture.runAsync(entityWriter, executor)).orElseGet(() -> CompletableFuture.runAsync(entityWriter));
-
-        return sendingFuture.thenCombine(httpResponseCompletableFuture, (aVoid, inputStreamHttpResponse) -> inputStreamHttpResponse);
+        final HttpRequest httpRequest = requestBuilder.method(method, HttpRequest.BodyPublishers.ofInputStream(() -> pipedInputStream)).build();
+        final CompletableFuture<HttpResponse<InputStream>> httpResponseCompletableFuture = httpClient.sendAsync(httpRequest, responseBodyHandler);
+        try {
+            clientRequest.writeEntity();
+        } catch (IOException e) {
+            httpResponseCompletableFuture.cancel(true);
+            throw new ProcessingException("The sending process failed with I/O error, " + e.getMessage(), e);
+        }
+        return httpResponseCompletableFuture;
     }
 
     public HttpClient getHttpClient() {


### PR DESCRIPTION
    Write the body in the calling thread to avoid spawning another thread - it causes thread starvation and header sent without body