### PR TITLE
Update Jersey to 3.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java: [ 11, 17, 18]
+        java: [ 11, 17, 19]
         experimental: [ false ]
         include:
-          - java: 19-ea
+          - java: 20-ea
             os: ubuntu-latest
             experimental: true
-          - java: 19-ea
+          - java: 20-ea
             os: macos-latest
             experimental: true
-          - java: 19-ea
+          - java: 20-ea
             os: windows-latest
             experimental: true
     name: Build with Java ${{ matrix.java }} on ${{ matrix.os }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,12 @@
 
     <groupId>com.github.nhenneaux.jersey.connector.httpclient</groupId>
     <artifactId>jersey-httpclient-connector</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
 
     <name>Jersey Connector using java.net.http.HttpClient</name>
-    <description>A Jersey connector using java.net.http.HttpClient and supporting HTTP/1.1 and HTTP/2.0 with the same client. The protocol is selected based on the server capabilities.</description>
+    <description>A Jersey connector using java.net.http.HttpClient and supporting HTTP/1.1 and HTTP/2.0 with the same
+        client. The protocol is selected based on the server capabilities.
+    </description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -22,9 +24,9 @@
         <sonar.organization>nhenneaux</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-        <jersey.version>3.0.8</jersey.version>
+        <jersey.version>3.1.0</jersey.version>
         <jetty.version>11.0.12</jetty.version>
-        <weld-se-core.version>4.0.3.Final</weld-se-core.version>
+        <weld-se-core.version>5.1.0.Final</weld-se-core.version>
         <log4j.version>2.19.0</log4j.version>
     </properties>
 
@@ -47,10 +49,23 @@
             <artifactId>jersey-cdi2-se</artifactId>
             <version>${jersey.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.weld.*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
+            <version>${weld-se-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.servlet</groupId>
+            <artifactId>weld-servlet-core</artifactId>
             <version>${weld-se-core.version}</version>
             <scope>test</scope>
         </dependency>
@@ -96,7 +111,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -121,7 +136,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.0</version>
+            <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -133,7 +148,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.8.0</version>
+            <version>4.9.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/com/github/nhenneaux/jersey/connector/httpclient/JettyServerTest.java
+++ b/src/test/java/com/github/nhenneaux/jersey/connector/httpclient/JettyServerTest.java
@@ -11,8 +11,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
-import org.jboss.weld.environment.se.Weld;
-import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -56,7 +54,9 @@ class JettyServerTest {
 
     static WebTarget getClient(int port) {
         return getClient(port, trustStore(), http2ClientConfig());
-    }    static WebTarget getClientChunk(int port) {
+    }
+
+    static WebTarget getClientChunk(int port) {
         return getClient(port, trustStore(), http2ClientConfig().property(ClientProperties.REQUEST_ENTITY_PROCESSING, "CHUNKED"));
     }
 
@@ -103,7 +103,9 @@ class JettyServerTest {
                 assertEquals(data, response.readEntity(DummyRestService.Data.class).getData());
             }
         }
-    }    @Test
+    }
+
+    @Test
     @Timeout(20)
     void testPostChunk() throws Exception {
         int port = PORT;
@@ -136,6 +138,7 @@ class JettyServerTest {
             }
         }
     }
+
     @Test
     @Timeout(20)
     void testPostAsyncChunk() throws Exception {
@@ -174,7 +177,9 @@ class JettyServerTest {
                 assertEquals(data, response.readEntity(DummyRestService.Data.class).getData());
             }
         }
-    }    @Test
+    }
+
+    @Test
     @Timeout(20)
     void testPostStringChunk() throws Exception {
         int port = PORT;
@@ -219,6 +224,7 @@ class JettyServerTest {
             }
         }
     }
+
     @Test
     @Timeout(20)
     void testPostBytesChunk() throws Exception {
@@ -260,6 +266,7 @@ class JettyServerTest {
             }
         }
     }
+
     @Test
     @Timeout(20)
     void testMethodPostChunk() throws Exception {
@@ -303,7 +310,8 @@ class JettyServerTest {
         });
         assertEquals(ConnectException.class, processingException.getCause().getClass());
     }
-  @Test
+
+    @Test
     @Timeout(20)
     void testConnectTimeoutChunk() throws Exception {
         int port = PORT;
@@ -433,13 +441,9 @@ class JettyServerTest {
         int port = PORT;
         JettyServer.TlsSecurityConfiguration tlsSecurityConfiguration = tlsConfig();
         for (int i = 0; i < 100; i++) {
-            try (
-                    @SuppressWarnings("unused") WeldContainer container = new Weld().initialize();
-                    AutoCloseable ignored = jerseyServer(port, tlsSecurityConfiguration, DummyRestService.class)
-            ) {
-                try (final var head = getClient(port).path(PING).request().head()) {
-                    assertEquals(204, head.getStatus());
-                }
+            try (var ignored = jerseyServer(port, tlsSecurityConfiguration, DummyRestService.class);
+                 var head = getClient(port).path(PING).request().head()) {
+                assertEquals(204, head.getStatus());
             }
         }
     }


### PR DESCRIPTION
Update test libraries
 - Weld 5.1.0
 - slf4j-api to 2.0.4
 - Junit to 5.9.1
 - mockito-junit-jupiter 4.9.0